### PR TITLE
[QLN-40] feat: user now can use otp to reset password

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -170,6 +170,12 @@
     "support": "Support",
     "signout": "Sign out"
   },
+  "Errors": {
+    "index": "Errors",
+    "token-expire": "The url has been expire, please create another request",
+    "invalid-pin": "Pin is not correct, please try again",
+    "account-fail": "The account has been terminated, please contact the Support"
+  },
   "Validations": {
     "errors": {
       "invalid_type": "Expected {{expected}}, received {{received}}",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.49.2",
+    "react-otp-input": "^3.1.1",
     "tailwind-merge": "^2.2.0",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ dependencies:
   react-hook-form:
     specifier: ^7.49.2
     version: 7.49.2(react@18.2.0)
+  react-otp-input:
+    specifier: ^3.1.1
+    version: 3.1.1(react-dom@18.2.0)(react@18.2.0)
   tailwind-merge:
     specifier: ^2.2.0
     version: 2.2.0
@@ -3861,6 +3864,16 @@ packages:
 
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  /react-otp-input@3.1.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-bjPavgJ0/Zmf/AYi4onj8FbH93IjeD+e8pWwxIJreDEWsU1ILR5fs8jEJmMGWSBe/yyvPP6X/W6Mk9UkOCkTPw==}
+    peerDependencies:
+      react: '>=16.8.6 || ^17.0.0 || ^18.0.0'
+      react-dom: '>=16.8.6 || ^17.0.0 || ^18.0.0'
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
 
   /react-remove-scroll-bar@2.3.4(@types/react@18.2.45)(react@18.2.0):
     resolution: {integrity: sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==}

--- a/src/app/[locale]/(auth)/forgot/actions/change-password-action.ts
+++ b/src/app/[locale]/(auth)/forgot/actions/change-password-action.ts
@@ -22,11 +22,14 @@ export const ChangePasswordAction = async (
   }
 
   return fetch(URL, options)
-    .then((response) => response.json())
-    .then((response) => {
+    .then(async (response) => {
       if (!response.ok) {
-        throw new Error(response.message)
+        const err = await response.json()
+        throw Error(err.message)
       }
+      return response.json()
+    })
+    .then((response) => {
       return {
         ok: true,
         message: response.message,

--- a/src/app/[locale]/(auth)/forgot/actions/forgot-password-action.ts
+++ b/src/app/[locale]/(auth)/forgot/actions/forgot-password-action.ts
@@ -24,7 +24,6 @@ export const ForgotPasswordAction = async (
         const err = await response.json()
         throw Error(err.message)
       }
-      console.log(response.headers)
       return response.json()
     })
     .then((response) => {
@@ -35,7 +34,6 @@ export const ForgotPasswordAction = async (
       }
     })
     .catch((error) => {
-      console.error(error)
       return {
         ok: false,
         message: error.message,

--- a/src/app/[locale]/(auth)/forgot/actions/resend-email-action.ts
+++ b/src/app/[locale]/(auth)/forgot/actions/resend-email-action.ts
@@ -3,24 +3,15 @@ import { validateJWT } from "@/lib/auth"
 import { getAPIServerURL } from "@/lib/utils"
 import { JwtPayload } from "jsonwebtoken"
 
-export const ResentEmailAction = async (token: string) => {
+export const ResentEmailAction = async (email: string) => {
   const URL = getAPIServerURL("/auth/forgot-password")
-  const jwt = validateJWT(
-    token,
-    process.env.FORGOT_PASSWORD_SECRET!
-  ) as JwtPayload
-  if (!jwt)
-    return {
-      ok: false,
-      message: "not valid token",
-      data: undefined,
-    }
   const options: RequestInit = {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ email: jwt.email }),
+    body: JSON.stringify({ email }),
+    cache: "no-cache",
   }
 
   return fetch(URL, options)
@@ -36,7 +27,6 @@ export const ResentEmailAction = async (token: string) => {
       return {
         ok: true,
         message: response.message,
-        data: token,
       }
     })
     .catch((error) => {
@@ -44,7 +34,6 @@ export const ResentEmailAction = async (token: string) => {
       return {
         ok: false,
         message: error.message,
-        data: null,
       }
     })
 }

--- a/src/app/[locale]/(auth)/forgot/component/change-password-form.tsx
+++ b/src/app/[locale]/(auth)/forgot/component/change-password-form.tsx
@@ -38,6 +38,7 @@ export default function ChangePasswordForm({
   token,
 }: ChangePasswordPageProps) {
   const t = useTranslations("ChangePassword")
+  const e = useTranslations("Errors")
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const router = useRouter()
 
@@ -52,8 +53,8 @@ export default function ChangePasswordForm({
     if (!result.ok) {
       setIsLoading(false)
       return toast({
-        title: "Something went wrong.",
-        description: t(result.message),
+        title: e("index"),
+        description: e(result.message),
         variant: "flat",
         color: "danger",
       })

--- a/src/app/[locale]/(auth)/forgot/component/forgot-password-form.tsx
+++ b/src/app/[locale]/(auth)/forgot/component/forgot-password-form.tsx
@@ -56,7 +56,7 @@ export default function ForgotPasswordForm() {
     searchParams.set("state", "sent")
     searchParams.set("email", values.email)
 
-    return router.push("/forgot?" + searchParams.toString())
+    return router.push("/forgot/reset-password?" + searchParams.toString())
   }
 
   return (

--- a/src/app/[locale]/(auth)/forgot/page.tsx
+++ b/src/app/[locale]/(auth)/forgot/page.tsx
@@ -1,29 +1,22 @@
 import GoBackButton from "@/components/go-back-btn"
 import _ from "lodash"
 import { NextIntlClientProvider } from "next-intl"
-import { getMessages, getTranslations } from "next-intl/server"
+import { getMessages } from "next-intl/server"
 import ForgotPasswordForm from "./component/forgot-password-form"
-import SentEmailCard from "./component/sent-email-card"
 
 type ForgotPasswordProps = {
   searchParams: { [key: string]: string | string[] | undefined }
 }
 
 async function ForgotPasswordPage({ searchParams }: ForgotPasswordProps) {
-  const t = await getTranslations("ForgotPassword")
-  const { state } = searchParams
   const m = await getMessages()
 
   return (
     <div className="h-full w-full">
       <GoBackButton />
-      {state === "sent" ? (
-        <SentEmailCard />
-      ) : (
-        <NextIntlClientProvider messages={_.pick(m, "ForgotPassword")}>
-          <ForgotPasswordForm />
-        </NextIntlClientProvider>
-      )}
+      <NextIntlClientProvider messages={_.pick(m, "ForgotPassword", "Erros")}>
+        <ForgotPasswordForm />
+      </NextIntlClientProvider>
     </div>
   )
 }

--- a/src/app/[locale]/(auth)/forgot/reset-password/page.tsx
+++ b/src/app/[locale]/(auth)/forgot/reset-password/page.tsx
@@ -2,19 +2,28 @@ import GoBackButton from "@/components/go-back-btn"
 import _ from "lodash"
 import { NextIntlClientProvider } from "next-intl"
 import { getMessages, getTranslations } from "next-intl/server"
+import VerifyForgotPasswordForm from "../component/verify-forgot-password-form"
+import { z } from "zod"
+import { notFound } from "next/navigation"
 
-type Props = {}
-
-async function ForgotPasswordPage({}: Props) {
-  const t = await getTranslations("ForgotPassword")
+type VerifyForgotPasswordPageProps = {
+  searchParams: { [key: string]: string | string[] | undefined }
+}
+async function ForgotPasswordPage({
+  searchParams,
+}: VerifyForgotPasswordPageProps) {
   const m = await getMessages()
+  const { email } = searchParams
+  const validate = z.string().email()
+  await validate.parseAsync(email).catch((e) => notFound())
 
   return (
     <div className="h-full w-full">
       <GoBackButton />
-      <NextIntlClientProvider messages={_.pick(m, "ForgotPassword")}>
-        {/* <ForgotPasswordForm /> */}
-        <div></div>
+      <NextIntlClientProvider
+        messages={_.pick(m, "VerifyForgotPassword", "Errors")}
+      >
+        <VerifyForgotPasswordForm email={email as string} />
       </NextIntlClientProvider>
     </div>
   )

--- a/src/app/[locale]/(auth)/forgot/validations/verify-forgot-password-validate.tsx
+++ b/src/app/[locale]/(auth)/forgot/validations/verify-forgot-password-validate.tsx
@@ -1,11 +1,10 @@
 import { z } from "zod"
 
-const VerifyForgotPasswordSchema = z
-  .object({
-    // TODO: change here
-    // otpCode: z.number()
-  })
-  
+const VerifyForgotPasswordSchema = z.object({
+  pin: z.string().length(6).regex(/^\d+$/),
+  email: z.string().email(),
+})
+
 type VerifyForgotPasswordSchemaType = z.infer<typeof VerifyForgotPasswordSchema>
 
 export default VerifyForgotPasswordSchema

--- a/src/app/[locale]/(auth)/forgot/verify/page.tsx
+++ b/src/app/[locale]/(auth)/forgot/verify/page.tsx
@@ -27,7 +27,7 @@ export default async function VerifyForgotPasswordPage({
   return (
     <div className="h-full w-full">
       <GoBackButton />
-      <NextIntlClientProvider messages={_.pick(m, "ChangePassword")}>
+      <NextIntlClientProvider messages={_.pick(m, "ChangePassword", "Errors")}>
         <ChangePasswordForm token={t as string} email={isValidToken.email} />
       </NextIntlClientProvider>
     </div>

--- a/src/app/[locale]/(auth)/signup/component/verify-sign-up.tsx
+++ b/src/app/[locale]/(auth)/signup/component/verify-sign-up.tsx
@@ -33,21 +33,21 @@ export function VerifyRegister() {
   const router = useRouter()
   const { toast } = useToast()
 
-  const [otp, setOtp] = useState<number>(0)
-  const handleOtpChange = (value: number) => {
-    setOtp(value)
+  const [otp, setOtp] = useState<string>("")
+  const handleOtpChange = (otp: string) => {
+    setOtp(otp)
   }
 
   async function onSubmit(values: VerifySignUpSchemaType) {
     setIsLoading(true)
 
     values = {
-      otpCode: otp
+      otpCode: otp,
     }
 
     // TODO: change here
     console.log(values)
-    
+
     const result = await VerifySignUpAction(values)
 
     if (!result?.ok) {
@@ -90,9 +90,7 @@ export function VerifyRegister() {
       </CardHeader>
 
       <CardContent>
-        <CardTitle className="flex justify-center">
-          {t("form.title")}
-        </CardTitle>
+        <CardTitle className="flex justify-center">{t("form.title")}</CardTitle>
         <Form {...form}>
           <form className="space-y-4" onSubmit={form.handleSubmit(onSubmit)}>
             <FormField
@@ -102,12 +100,7 @@ export function VerifyRegister() {
                 return (
                   <div className="mt-2 flex justify-center">
                     <FormControl>
-                      <Otp
-                        length={4}
-                        otp={otp}
-                        onOtpChange={handleOtpChange}
-                        {...field}
-                      />
+                      <Otp {...field} value={otp} onChange={handleOtpChange} />
                     </FormControl>
                     <FormMessage />
                   </div>

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -65,7 +65,7 @@ type Props = {
   }
 }
 export default function LocaleLayout({ children, params: { locale } }: Props) {
-  const messages = useMessages();
+  const messages = useMessages()
   return (
     <html lang={locale} suppressHydrationWarning>
       <body
@@ -79,8 +79,8 @@ export default function LocaleLayout({ children, params: { locale } }: Props) {
           <NextIntlClientProvider
             locale={locale}
             messages={pick(messages, "NotFound", "Error")}
-            >
-              {children}
+          >
+            {children}
           </NextIntlClientProvider>
         </GoogleProvider>
         <Toaster />

--- a/src/components/ui/otp.tsx
+++ b/src/components/ui/otp.tsx
@@ -27,7 +27,7 @@ const Otp = ({
         />
       )
     },
-    []
+    [inputClassName]
   )
   return (
     <OtpInput

--- a/src/components/ui/otp.tsx
+++ b/src/components/ui/otp.tsx
@@ -1,74 +1,42 @@
-import { Input } from "@/components/ui/input";
-import { useState, Fragment, useRef, useEffect } from "react";
+import { cn } from "@/lib/utils"
+import { useCallback } from "react"
+import OtpInput, { InputProps, OTPInputProps } from "react-otp-input"
 
-type OtpInputProps = {
-  length: number;
-  otp: number;
-  onOtpChange: (otp: number) => void;
-};
+type OTPProps = Omit<OTPInputProps, "renderInput" | "containerStyle"> & {
+  className?: string
+  inputClassName?: string
+}
 
-let currentOtpIndex: number = 0;
-
-const Otp = ({ length, otp, onOtpChange }: OtpInputProps): JSX.Element => {
-  const [tempOtp, setTempOtp] = useState<string[]>(
-    new Array(length || 6).fill("")
-  );
-  const [activeOtpIndex, setActiveOtpIndex] = useState<number>(0);
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  const handleOnchange = ({
-    target,
-  }: React.ChangeEvent<HTMLInputElement>): void => {
-    const { value } = target;
-    const newOtp: string[] = [...tempOtp];
-    newOtp[currentOtpIndex] = value.substring(value.length - 1);
-
-    if (!value) setActiveOtpIndex(currentOtpIndex - 1);
-    else setActiveOtpIndex(currentOtpIndex + 1);
-
-    setTempOtp(newOtp);
-    onOtpChange(
-      isNaN(parseInt(newOtp.join(""))) ? 0 : parseInt(newOtp.join(""))
-    );
-    otp = isNaN(parseInt(tempOtp.join(""))) ? 0 : parseInt(tempOtp.join(""));
-  };
-
-  const handleOnKeyDown = (
-    { key }: React.KeyboardEvent<HTMLInputElement>,
-    index: number
-  ) => {
-    currentOtpIndex = index;
-    if (key === "Backspace") {
-      setActiveOtpIndex(currentOtpIndex - 1);
-    }
-  };
-
-  useEffect(() => {
-    inputRef.current?.focus();
-  }, [activeOtpIndex]);
-
+const Otp = ({
+  className,
+  inputClassName,
+  numInputs = 6,
+  ...props
+}: OTPProps): JSX.Element => {
+  const renderInput = useCallback(
+    ({ className, ...props }: InputProps, index: number) => {
+      return (
+        <input
+          className={cn(
+            "rounded-md border border-neutral-300 bg-neutral-50",
+            "min-h-10 min-w-8",
+            className,
+            inputClassName
+          )}
+          {...props}
+        />
+      )
+    },
+    []
+  )
   return (
-    <div className="flex items-center space-x-2 w-fit">
-      {tempOtp.map((_, index) => {
-        return (
-          <Fragment key={index}>
-            <Input
-              ref={index === activeOtpIndex ? inputRef : null}
-              onChange={handleOnchange}
-              onKeyDown={(e) => handleOnKeyDown(e, index)}
-              className="w-10 text-center placeholder:text-slate-300 dark:placeholder:text-slate-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-              type="number"
-              placeholder={(index + 1).toString()}
-              value={tempOtp[index]}
-            />
-            {index === tempOtp.length - 1 ? null : (
-              <span className="w-2 py-[0.5px] bg-foreground" />
-            )}
-          </Fragment>
-        );
-      })}
-    </div>
-  );
-};
+    <OtpInput
+      containerStyle={cn("gap-2", className)}
+      renderInput={renderInput}
+      numInputs={numInputs}
+      {...props}
+    />
+  )
+}
 
-export default Otp;
+export default Otp


### PR DESCRIPTION
# Test
## Successfully reset password use OTP
1. Hit `[auth/forgot-passwod](http://localhost:3000/forgot)` and fill the registered email
2. Copy OTP from email
3. The browser will auto redirect to **[fill otp page](http://localhost:3000/forgot/reset-password?state=sent&email=ngocvlqt1995%40gmail.com)**
4. change password

Expected:
- Successfully change password

## Redirect to Not found when provide invalid email
1. Navigate to fill otp page at http://localhost:3000/forgot/reset-password?state=sent&email=ngocvlqt1995%40gmail.com
2. Change the email after `email` search params to invalid email (example: 123 or notAnEmail)

Expected:
- redirect to Not found page