### PR TITLE
[QLN-288] fix: navigate to login for guesses [QLN-310] fix: revalidate path when search for user

### DIFF
--- a/src/app/[locale]/(main)/classrooms/[id]/(students)/actions/fetch-classroom-members.ts
+++ b/src/app/[locale]/(main)/classrooms/[id]/(students)/actions/fetch-classroom-members.ts
@@ -5,6 +5,7 @@ import { getAPIServerURL } from "@/lib/utils"
 import { Classroom, User } from "@/types"
 import PagedRequest from "@/types/paged-request"
 import PagedResponse from "@/types/paged-response"
+import { revalidatePath, revalidateTag } from "next/cache"
 
 export type StudentClasroomData = {
   account: User,
@@ -81,7 +82,10 @@ export async function getBanMembers(
   )
 
   return fetch(url, option)
-    .then(async (res) => res.json())
+    .then(async (res) => {
+      revalidatePath(`classrooms/${classroomId}/members`)
+      revalidatePath(`classrooms/${classroomId}/manage`)
+      return res.json()})
     .catch((err) => {
       console.error(`[ERROR] get Banned Users: ${URL} `, err)
       throw new Error(err)

--- a/src/app/[locale]/(main)/classrooms/layout.tsx
+++ b/src/app/[locale]/(main)/classrooms/layout.tsx
@@ -1,20 +1,39 @@
 import BackgroundSquare from "@/components/background-square"
 import { getUser } from "@/lib/auth"
-import { notFound } from "next/navigation"
+import { pick } from "lodash"
+import { NextIntlClientProvider, useMessages, useTranslations } from "next-intl"
+import { RedirectType, redirect } from "next/navigation"
 
 type Props = { children?: React.ReactNode }
 
 function ClassroomLayout({ children }: Props) {
+  const t = useTranslations("Errors")
+  const msg = useMessages()
+
   const user = getUser()
-  if (!user) return notFound()
-  return (
-    <BackgroundSquare
-      variant={"topDown"}
-      className="container mx-auto items-start pt-20"
-    >
-      <div className="relative">{children}</div>
-    </BackgroundSquare>
-  )
+  if (!user) {
+    redirect("/login", RedirectType.push)
+  } else {
+    return (
+      <NextIntlClientProvider
+        messages={pick(
+          msg,
+          "Validations",
+          "Join_classroom",
+          "Errors",
+          "Delete_classroom",
+          "Classroom"
+        )}
+      >
+        <BackgroundSquare
+          variant={"topDown"}
+          className="container mx-auto items-start pt-20"
+        >
+          <div className="relative">{children}</div>
+        </BackgroundSquare>
+      </NextIntlClientProvider>
+    )
+  }
 }
 
 export default ClassroomLayout

--- a/src/app/[locale]/(main)/classrooms/page.tsx
+++ b/src/app/[locale]/(main)/classrooms/page.tsx
@@ -6,8 +6,7 @@ import { Button } from "@/components/ui/button"
 import { Icons } from "@/components/ui/icons"
 import { NamedToolTip } from "@/components/ui/tooltip"
 import _ from "lodash"
-import { NextIntlClientProvider } from "next-intl"
-import { getMessages, getTranslations } from "next-intl/server"
+import { getTranslations } from "next-intl/server"
 import Link from "next/link"
 
 type Props = {
@@ -22,7 +21,6 @@ export async function generateMetadata() {
   }
 }
 async function ClassroomPage({ searchParams }: Props) {
-  const msg = await getMessages()
   const t = await getTranslations("Classroom")
   const initCode = searchParams["code"] as string | undefined
   const search = searchParams["search"] as string | undefined
@@ -32,16 +30,7 @@ async function ClassroomPage({ searchParams }: Props) {
   }
 
   return (
-    <NextIntlClientProvider
-      messages={_.pick(
-        msg,
-        "Validations",
-        "Join_classroom",
-        "Errors",
-        "Delete_classroom",
-        "Classroom"
-      )}
-    >
+    <>
       <div className="mb-4 flex items-center justify-between">
         <h1 className="text-xl font-bold">{t("metadata.title")}</h1>
         <div className="flex items-center gap-2">
@@ -61,7 +50,7 @@ async function ClassroomPage({ searchParams }: Props) {
         </div>
       </div>
       <ClassroomList initialData={data!} filter={{ search }} />
-    </NextIntlClientProvider>
+    </>
   )
 }
 

--- a/src/app/[locale]/(main)/layout.tsx
+++ b/src/app/[locale]/(main)/layout.tsx
@@ -31,6 +31,9 @@ async function MainLayout({ children }: Props) {
   const isAuth = isAuthenticated()
   const user = getUser()
   const m = await getMessages()
+  // * For routes has not been defined
+  const defaultRoute = "/login"
+
   const menuItems: MenuItem[][] = [
     [
       {
@@ -103,7 +106,7 @@ async function MainLayout({ children }: Props) {
     },
     {
       title: tNav("contact"),
-      href: "/contact",
+      href: defaultRoute,
       icon: "Contact",
     },
     {
@@ -147,6 +150,7 @@ async function MainLayout({ children }: Props) {
       <GuestNavbar
         className="fixed left-1/2 top-0 w-screen -translate-x-1/2"
         items={mainNavbarItems}
+        defaultRoute={defaultRoute}
       />
     )
 

--- a/src/components/ui/guest-navbar/guest-navbar.tsx
+++ b/src/components/ui/guest-navbar/guest-navbar.tsx
@@ -35,9 +35,14 @@ export type MainNavItem = {
 type Props = {
   items?: MainNavItem[]
   className?: string
+  defaultRoute: string
 }
 
-export default function GuestNavbar({ className, items = [] }: Props) {
+export default function GuestNavbar({
+  className,
+  items = [],
+  defaultRoute,
+}: Props) {
   const segment = useSelectedLayoutSegment()
   // const [showMobileMenu, setShowMobileMenu] = React.useState<boolean>(false)
   const tNav = useTranslations("Navbar")
@@ -178,19 +183,19 @@ export default function GuestNavbar({ className, items = [] }: Props) {
                 </NavigationMenuLink>
               </li>
               <ListItem
-                href="/docs"
+                href={defaultRoute}
                 title={tNav("getting_started_sec.introduction.title")}
               >
                 {tNav("getting_started_sec.introduction.description")}
               </ListItem>
               <ListItem
-                href="/docs/installation"
+                href={defaultRoute}
                 title={tNav("getting_started_sec.classroom.title")}
               >
                 {tNav("getting_started_sec.classroom.description")}
               </ListItem>
               <ListItem
-                href="/docs/primitives/typography"
+                href={defaultRoute}
                 title={tNav("getting_started_sec.ai.title")}
               >
                 <span>{tNav("getting_started_sec.ai.description")}</span>
@@ -212,7 +217,7 @@ export default function GuestNavbar({ className, items = [] }: Props) {
           </NavigationMenuContent>
         </NavigationMenuItem>
         <NavigationMenuItem>
-          <Link href="/docs" legacyBehavior passHref>
+          <Link href={defaultRoute} legacyBehavior passHref>
             <NavigationMenuLink className={navigationMenuTriggerStyle()}>
               {tNav("doc")}
             </NavigationMenuLink>


### PR DESCRIPTION
- All navigation links from header navbar that have not yet defined will navigate to "/login"
- Re-validate path after search for user